### PR TITLE
Fix query string parsing

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -25,7 +25,10 @@ export const fetchSearchResults = (filters) => (dispatch) => {
     filters
   });
 
-  return endpoint.get('search', {params: {...filters, facet: 'schema'}})
+  return endpoint.get('search', {
+      params: { ...filters, facet: 'schema' },
+      paramsSerializer: queryString.stringify
+    })
     .then(response => {
       const result = response.data;
 

--- a/src/components/SearchFilter.js
+++ b/src/components/SearchFilter.js
@@ -70,12 +70,11 @@ class SearchFilter extends Component {
         <div className="search-query">
           <div className="search-query__text pt-input-group pt-large">
             <span className="pt-icon pt-icon-search"/>
-            <input className="pt-input" type="search" onChange={this.onTextChange}
-              value={query.q}/>
+            <input className="pt-input" type="search" onChange={this.onTextChange} value={query.q} />
           </div>
           <div className="search-query__button pt-large">
             <SearchFilterCountries onChange={this.onCountriesChange} onOpen={this.onCountriesOpen}
-              value={query['filter:countries'] || []} countries={countries} loaded={countriesLoaded} />
+              currentCountries={query['filter:countries']} countries={countries} loaded={countriesLoaded} />
           </div>
           <div className="search-query__button pt-large">
             <Button rightIconName="caret-down">
@@ -86,7 +85,7 @@ class SearchFilter extends Component {
         </div>
         { result.total > 0 &&
           <SearchFilterSchema onChange={this.onSchemaChange} result={result}
-            value={query['filter:schema']} /> }
+            currentSchema={query['filter:schema']} /> }
       </div>
     );
   }

--- a/src/components/SearchFilterCountries.js
+++ b/src/components/SearchFilterCountries.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Button, Popover, Position, Spinner } from '@blueprintjs/core';
 
-const SearchFilterCountries = ({ loaded, countries, value, onOpen, onChange }) => {
+const SearchFilterCountries = ({ loaded, countries, currentCountries, onOpen, onChange }) => {
 
   function toggleCountryId(countryId) {
-    const newValue = value.indexOf(countryId) > -1 ?
-      value.filter(i => i !== countryId) : [...value, countryId];
+    const newValue = currentCountries.indexOf(countryId) > -1 ?
+      currentCountries.filter(i => i !== countryId) : [...currentCountries, countryId];
 
     onChange(newValue);
   }
@@ -23,7 +23,7 @@ const SearchFilterCountries = ({ loaded, countries, value, onOpen, onChange }) =
             {countries.map(country => (
               <li onClick={toggleCountryId.bind(null, country.id)} key={country.id}>
                 <span className="pt-icon-standard pt-icon-tick"
-                  style={{'visibility': value.indexOf(country.id) > -1 ? 'visible': 'hidden'}} />
+                  style={{'visibility': currentCountries.indexOf(country.id) > -1 ? 'visible': 'hidden'}} />
                 {country.label}
               </li>
             ))}

--- a/src/components/SearchFilterSchema.js
+++ b/src/components/SearchFilterSchema.js
@@ -4,12 +4,12 @@ import { Tab2, Tabs2 } from '@blueprintjs/core';
 
 import SchemaIcon from './SchemaIcon';
 
-const SearchFilterSchema = ({ onChange, result, value }) => {
+const SearchFilterSchema = ({ onChange, result, currentSchema }) => {
   const schemas = result.facets.schema.values.sort((a, b) => a.label < b.label ? -1 : 1);
 
   return (
     <Tabs2 id="schemaTypes" className="search-filter-schema pt-large pt-dark" onChange={onChange}
-      selectedTabId={value}>
+      selectedTabId={currentSchema}>
       <Tab2 id={null}>
         <FormattedMessage id="search.schema.all" defaultMessage="All Results"/>
         {' '}(<FormattedNumber value={schemas.reduce((total, schema) => total + schema.count, 0)} />)

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -53,6 +53,7 @@ class SearchScreen extends Component {
 
 const mapStateToProps = ({ searchResults }, { location }) => {
   const query = queryString.parse(location.search);
+  console.warn(query);
   return { query, searchResults };
 }
 

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -1,12 +1,26 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import queryString from 'query-string';
-import { debounce, isEqual, pickBy } from 'lodash';
+import { debounce, isEqual, pickBy, mergeWith, isArray } from 'lodash';
 
 import { fetchSearchResults } from '../actions';
 
 import SearchResultList from '../components/SearchResultList';
 import SearchFilter from '../components/SearchFilter';
+
+function parseQuery(search) {
+  const searchQuery = queryString.parse(search);
+
+  return mergeWith({
+    'q': '',
+    'filter:schema': '',
+    'filter:countries': []
+  }, searchQuery, (defaultValue, newValue) => {
+    return newValue !== undefined ?
+      isArray(defaultValue) ? defaultValue.concat(newValue) : newValue :
+      defaultValue;
+  });
+}
 
 class SearchScreen extends Component {
   constructor() {
@@ -52,8 +66,7 @@ class SearchScreen extends Component {
 }
 
 const mapStateToProps = ({ searchResults }, { location }) => {
-  const query = queryString.parse(location.search);
-  console.warn(query);
+  const query = parseQuery(location.search);
   return { query, searchResults };
 }
 


### PR DESCRIPTION
- Use non-array format when sending query string parameters to API
  `blah=foo&blah=bar` over `blah[]=foo&blah[]=bar`
- Set defaults for search UI query string parameters