### PR TITLE
Search filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@blueprintjs/core": "^1.22.0",
     "axios": "^0.16.2",
     "bourbon": "^4.3.2",
+    "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "node-sass-package-importer": "^3.0.4",
     "normalizr": "^3.2.2",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,7 +4,7 @@ import { endpoint } from '../api';
 
 export const fetchCollections = (ids, params={}) => (dispatch, getState) => {
   const { collections } = getState();
-  const newIds = uniq(ids).filter(id => !collections[id]);
+  const newIds = uniq(ids).filter(id => !collections.results[id]);
 
   function fetchCollectionsPages(page=1) {
     const limit = 50;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,7 +2,7 @@ import uniq from 'lodash/uniq';
 
 import { endpoint } from '../api';
 
-export const fetchCollections = (ids, params={}) => (dispatch, getState) => {
+export const fetchCollections = ids => (dispatch, getState) => {
   const { collections } = getState();
   const newIds = uniq(ids).filter(id => !collections.results[id]);
 
@@ -10,7 +10,7 @@ export const fetchCollections = (ids, params={}) => (dispatch, getState) => {
     const limit = 50;
 
     return endpoint.get('collections', {
-        params: { ...params, 'filter:id': newIds, limit, offset: (page - 1) * limit }
+        params: { 'filter:id': newIds, limit, offset: (page - 1) * limit }
       })
       .then(response => {
         dispatch({

--- a/src/components/SearchFilter.js
+++ b/src/components/SearchFilter.js
@@ -1,7 +1,4 @@
 import React, { Component } from 'react';
-import keyBy from 'lodash/keyBy';
-
-import { endpoint } from '../api';
 
 import SearchFilterCountries from './SearchFilterCountries';
 import SearchFilterCollections from './SearchFilterCollections';
@@ -9,28 +6,24 @@ import SearchFilterSchema from './SearchFilterSchema';
 
 import './SearchFilter.css';
 
+const SearchFilterText = ({ currentValue, onChange }) => (
+  <div className="search-query__text pt-input-group pt-large">
+    <span className="pt-icon pt-icon-search"/>
+    <input className="search-input pt-input" type="search"
+      onChange={evt => onChange(evt.target.value)} value={currentValue} />
+  </div>
+);
+
 class SearchFilter extends Component {
   constructor(props)  {
     super(props);
 
     this.state = {
-      query: props.query,
-      countries: [],
-      countriesLoaded: false,
-      collections: [],
-      collectionDetails: {},
-      collectionCategories: [],
-      collectionCountries: [],
-      collectionsLoaded: false
+      query: props.query
     };
-
-    this.onTextChange = this.onTextChange.bind(this);
-
-    this.onCollectionsOpen = this.onCollectionsOpen.bind(this);
-    this.onCountriesOpen = this.onCountriesOpen.bind(this);
   }
 
-  handleQueryChange(key, value) {
+  onChange(key, value) {
     const query = {
       ...this.state.query,
       [key]: value
@@ -40,71 +33,27 @@ class SearchFilter extends Component {
     this.props.updateQuery(query);
   }
 
-  onTextChange(e) {
-    this.handleQueryChange('q', e.target.value);
-    this.setState({countriesLoaded: false, collectionsLoaded: false});
-  }
-
-  onCountriesOpen() {
-    if (!this.state.countriesLoaded) {
-      endpoint.get('search', {params: {q: this.state.query.q, facet: 'countries'}})
-        .then(response => {
-          this.setState({
-            countries: response.data.facets.countries.values,
-            countriesLoaded: true
-          });
-        });
-    }
-  }
-
-  onCollectionsOpen() {
-    if (!this.state.collectionsLoaded) {
-      endpoint.get('search', {params: {q: this.state.query.q, facet: 'collection_id'}})
-        .then(response => {
-          const collections = response.data.facets.collection_id.values;
-          this.setState({collections, collectionsLoaded: true});
-
-          return endpoint.get('collections', {params: {
-            'filter:id': collections.map(collection => collection.id),
-            'facet': ['countries', 'category']
-          }});
-        })
-        .then(response => this.setState({
-          collectionDetails: keyBy(response.data.results, collection => collection.id),
-          collectionCountries: response.data.facets.countries.values,
-          collectionCategories: response.data.facets.category.values
-        }));
-    }
-  }
-
   render() {
-    const { query, countries, countriesLoaded, collections, collectionsLoaded,
-      collectionDetails, collectionCategories, collectionCountries } = this.state;
     const { result } = this.props;
+    const { query } = this.state;
 
     const filterProps = key => {
       return {
-        onChange: value => this.handleQueryChange(key, value),
-        currentValue: query[key]
+        onChange: value => this.onChange(key, value),
+        currentValue: query[key],
+        queryText: query.q
       };
     };
 
     return (
       <div className="search-filter">
         <div className="search-query">
-          <div className="search-query__text pt-input-group pt-large">
-            <span className="pt-icon pt-icon-search"/>
-            <input className="search-input pt-input" type="search" onChange={this.onTextChange} value={query.q} />
+          <SearchFilterText {...filterProps('q')} />
+          <div className="search-query__button pt-large">
+            <SearchFilterCountries {...filterProps('filter:countries')} />
           </div>
           <div className="search-query__button pt-large">
-            <SearchFilterCountries onOpen={this.onCountriesOpen} countries={countries}
-              loaded={countriesLoaded} {...filterProps('filter:countries')} />
-          </div>
-          <div className="search-query__button pt-large">
-            <SearchFilterCollections onOpen={this.onCollectionsOpen} collections={collections}
-              details={collectionDetails} categories={collectionCategories}
-              countries={collectionCountries} loaded={collectionsLoaded}
-              {...filterProps('filter:collection_id')} />
+            <SearchFilterCollections {...filterProps('filter:collection_id')} />
           </div>
         </div>
         { result.total > 0 &&

--- a/src/components/SearchFilter.js
+++ b/src/components/SearchFilter.js
@@ -39,7 +39,7 @@ class SearchFilter extends Component {
 
     const filterProps = key => {
       return {
-        onChange: value => this.onChange(key, value),
+        onChange: this.onChange.bind(this, key),
         currentValue: query[key],
         queryText: query.q
       };

--- a/src/components/SearchFilter.scss
+++ b/src/components/SearchFilter.scss
@@ -38,3 +38,15 @@
   overflow: hidden;
   padding: $pt-grid-size;
 }
+
+.search-tick {
+  &::before {
+    content: $pt-icon-tick;
+  }
+
+  opacity: 0.1;
+  &.is-ticked {
+    transition: opacity 0.2s ease-out;
+    opacity: 1;
+  }
+}

--- a/src/components/SearchFilterCollections.js
+++ b/src/components/SearchFilterCollections.js
@@ -9,7 +9,7 @@ const mapStateToProps = ({ collections },  { collection }) => ({
   // Use more detailed collection data if we have it, fallback to basic
   // TEMP: parseInt until collection ids are made to be strings
   // https://github.com/alephdata/aleph/issues/224
-  collection: collections[parseInt(collection.id, 10)] || collection
+  collection: collections.results[parseInt(collection.id, 10)] || collection
 });
 
 const SearchFilterCollectionsItem = connect(mapStateToProps)(({ collection }) => (

--- a/src/components/SearchFilterCollections.js
+++ b/src/components/SearchFilterCollections.js
@@ -139,13 +139,13 @@ class SearchFilterCollections extends Component {
           <FormattedMessage id="search.collections" defaultMessage="Collections"/>
           {loaded && <span> (<FormattedNumber value={collections.length} />)</span>}
         </Button>
-        <Dialog isOpen={isOpen} onClose={this.toggleOpen} className="search-filter-collections">
+        <Dialog isOpen={isOpen} onClose={this.toggleOpen} title="Select collections"
+                className="search-filter-collections-dialog">
           {loaded ?
-            // No wrapping element so we can use Dialog's flexbox
-            [
-              <SearchFilterCollectionsList collections={collections} details={details} key={1} />,
+            <div className="search-filter-collections">
+              <SearchFilterCollectionsList collections={collections} details={details} onClick={this.toggleCollection} key={1} />,
               <SearchFilterCollectionsFacets facets={facets} onClick={this.toggleFacetItem} key={2} />
-            ] :
+            </div> :
             <Spinner className="search-filter-loading pt-large" />}
         </Dialog>
       </div>

--- a/src/components/SearchFilterCollections.js
+++ b/src/components/SearchFilterCollections.js
@@ -94,21 +94,21 @@ class SearchFilterCollections extends Component {
     const { isOpen, loaded, collections, details, categories, countries } = this.state;
 
     return (
-    <div>
-      <Button rightIconName="caret-down" onClick={this.toggleDialog}>
-        <FormattedMessage id="search.collections" defaultMessage="Collections"/>
-        {loaded && <span> (<FormattedNumber value={collections.length} />)</span>}
-      </Button>
-      <Dialog isOpen={isOpen} onClose={this.toggleDialog} className="search-filter-collections">
-        {loaded ?
-          // No wrapping element so these are direct descedents of Dialog for its flexbox
-          [
-            <SearchFilterCollectionsList collections={collections} details={details} key={1} />,
-            <SearchFilterCollectionsFilter categories={categories} countries={countries} key={2} />
-          ] :
-          <Spinner className="search-filter-loading pt-large" />}
-      </Dialog>
-    </div>
+      <div>
+        <Button rightIconName="caret-down" onClick={this.toggleDialog}>
+          <FormattedMessage id="search.collections" defaultMessage="Collections"/>
+          {loaded && <span> (<FormattedNumber value={collections.length} />)</span>}
+        </Button>
+        <Dialog isOpen={isOpen} onClose={this.toggleDialog} className="search-filter-collections">
+          {loaded ?
+            // No wrapping element so we can use Dialog's flexbox
+            [
+              <SearchFilterCollectionsList collections={collections} details={details} key={1} />,
+              <SearchFilterCollectionsFilter categories={categories} countries={countries} key={2} />
+            ] :
+            <Spinner className="search-filter-loading pt-large" />}
+        </Dialog>
+      </div>
     );
   }
 }

--- a/src/components/SearchFilterCollections.js
+++ b/src/components/SearchFilterCollections.js
@@ -1,25 +1,10 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Button, Dialog, Spinner } from '@blueprintjs/core';
 
 import './SearchFilterCollections.css';
 
-const mapStateToProps = ({ collections },  { collection }) => ({
-  // Use more detailed collection data if we have it, fallback to basic
-  // TEMP: parseInt until collection ids are made to be strings
-  // https://github.com/alephdata/aleph/issues/224
-  collection: collections.results[parseInt(collection.id, 10)] || collection
-});
-
-const SearchFilterCollectionsItem = connect(mapStateToProps)(({ collection }) => (
-  <li>
-    <h6>{ collection.label }</h6>
-    <p>{ collection.summary }</p>
-  </li>
-));
-
-const SearchFilterCollectionsList = ({ collections }) => (
+const SearchFilterCollectionsList = ({ collections, details }) => (
   <div className="search-filter-collections-col">
     <div className="search-filter-collections-col__row">
       <div className="pt-input-group pt-large">
@@ -30,22 +15,29 @@ const SearchFilterCollectionsList = ({ collections }) => (
     <div className="search-filter-collections-col__flex-row">
       <ul className="search-filter-collections-list">
         {collections.map(collection => (
-          <SearchFilterCollectionsItem collection={collection} key={collection.id} />
+          <li key={collection.id}>
+            <h6>{ collection.label }</h6>
+            {details[collection.id] && <p>{ details[collection.id].summary }</p>}
+          </li>
         ))}
       </ul>
     </div>
   </div>
 );
 
-const SearchFilterCollectionsFilter = () => (
+const SearchFilterCollectionsFilter = ({ categories, countries }) => (
   <div className="search-filter-collections-col">
     <div className="search-filter-collections-col__flex-row">
       <h4>Categories</h4>
-      stuff here
+      <ul className="search-filter-collections-facet">
+        {categories.map(category => <li key={category.id}>{category.label}</li>)}
+      </ul>
     </div>
     <div className="search-filter-collections-col__flex-row">
-      <h4>Collections</h4>
-      here too
+      <h4>Countries</h4>
+      <ul className="search-filter-collections-facet">
+        {countries.map(country => <li key={country.id}>{country.label}</li>)}
+      </ul>
     </div>
   </div>
 );
@@ -72,7 +64,7 @@ class SearchFilterCollections extends Component {
 
   render() {
     const { isOpen } = this.state;
-    const { loaded, collections } = this.props;
+    const { loaded, collections, details, categories, countries } = this.props;
 
     return (
     <div>
@@ -85,8 +77,8 @@ class SearchFilterCollections extends Component {
           // Doesn't use wrapping element so these are a direct descedent of Dialog
           // and can use its flexbox
           [
-            <SearchFilterCollectionsList collections={collections} key={1} />,
-            <SearchFilterCollectionsFilter key={2} />
+            <SearchFilterCollectionsList collections={collections} details={details} key={1} />,
+            <SearchFilterCollectionsFilter categories={categories} countries={countries} key={2} />
           ] :
           <Spinner className="search-filter-loading pt-large" />}
       </Dialog>

--- a/src/components/SearchFilterCollections.js
+++ b/src/components/SearchFilterCollections.js
@@ -150,8 +150,8 @@ class SearchFilterCollections extends Component {
                 className="search-filter-collections-dialog">
           {loaded ?
             <div className="search-filter-collections">
-              <SearchFilterCollectionsList collections={collections} details={details} onClick={this.toggleCollection} key={1} />,
-              <SearchFilterCollectionsFacets facets={facets} onClick={this.toggleFacetItem} key={2} />
+              <SearchFilterCollectionsList collections={collections} details={details} onClick={this.toggleCollection} />
+              <SearchFilterCollectionsFacets facets={facets} onClick={this.toggleFacetItem} />
             </div> :
             <Spinner className="search-filter-loading pt-large" />}
         </Dialog>

--- a/src/components/SearchFilterCollections.js
+++ b/src/components/SearchFilterCollections.js
@@ -9,7 +9,7 @@ import SearchFilterTick from './SearchFilterTick';
 
 import './SearchFilterCollections.css';
 
-const SearchFilterCollectionsList = ({ collections, details }) => (
+const SearchFilterCollectionsList = ({ collections, details, onClick }) => (
   <div className="search-filter-collections-col">
     <div className="search-filter-collections-col__row">
       <div className="pt-input-group pt-large">
@@ -20,7 +20,7 @@ const SearchFilterCollectionsList = ({ collections, details }) => (
     <div className="search-filter-collections-col__flex-row">
       <ul className="search-filter-collections-list">
         {collections.map(collection => (
-          <li key={collection.id}>
+          <li key={collection.id} onClick={onClick.bind(null, collection.id)}>
             <h6>{ collection.label }</h6>
             {details[collection.id] && <p>{ details[collection.id].summary }</p>}
           </li>
@@ -69,6 +69,7 @@ class SearchFilterCollections extends Component {
 
     this.toggleOpen = this.toggleOpen.bind(this);
     this.toggleFacetItem = this.toggleFacetItem.bind(this);
+    this.toggleCollection = this.toggleCollection.bind(this);
   }
 
   componentDidUpdate({ queryText }) {
@@ -128,6 +129,12 @@ class SearchFilterCollections extends Component {
 
     this.setState({facets});
     this.fetchCollections();
+  }
+
+  toggleCollection(collectionId) {
+    const { currentValue, onChange } = this.props;
+    const newValue = xor(currentValue, [collectionId]);
+    onChange(newValue);
   }
 
   render() {

--- a/src/components/SearchFilterCollections.js
+++ b/src/components/SearchFilterCollections.js
@@ -5,6 +5,8 @@ import { keyBy, xor, debounce, fromPairs } from 'lodash';
 
 import { endpoint } from '../api';
 
+import SearchFilterTick from './SearchFilterTick';
+
 import './SearchFilterCollections.css';
 
 const SearchFilterCollectionsList = ({ collections, details }) => (
@@ -36,8 +38,7 @@ const SearchFilterCollectionsFacets = ({ facets, onClick }) => (
         <ul className="search-filter-collections-facet">
           {facet.items.map(item => (
             <li key={item.id} onClick={onClick.bind(null, facet.id, item.id)}>
-              <span className="pt-icon-standard pt-icon-tick"
-                style={{'visibility': facet.selectedItems.indexOf(item.id) > -1 ? 'visible': 'hidden'}} />
+              <SearchFilterTick isTicked={facet.selectedItems.indexOf(item.id) > -1} />
               {item.label}
             </li>
           ))}

--- a/src/components/SearchFilterCollections.scss
+++ b/src/components/SearchFilterCollections.scss
@@ -1,12 +1,15 @@
 @import "~@blueprintjs/core/dist/variables";
 
 // Overrides some .pt-dialog CSS
-.search-filter-collections.pt-dialog {
+.search-filter-collections-dialog.pt-dialog {
+  top: $pt-grid-size;
   bottom: $pt-grid-size;
   width: calc(100% - #{$pt-grid-size * 4});
-  padding: $pt-grid-size 0;
-  flex-direction: row;
-  background-color: $white;
+}
+
+.search-filter-collections {
+  display: flex;
+  height: 100%;
 }
 
 .search-filter-collections-col {
@@ -57,7 +60,7 @@
     }
 
     &:nth-child(odd) {
-      background: $light-gray4;
+      background: $light-gray5;
     }
 
     &:hover {
@@ -77,7 +80,7 @@
     padding: ($pt-grid-size / 2) $pt-grid-size;
     padding-left: ($pt-icon-size-standard + $pt-grid-size * 2);
 
-    & > .pt-icon-standard {
+    & > .search-tick {
       position: absolute;
       left: $pt-grid-size;
       top: ($pt-grid-size / 2);

--- a/src/components/SearchFilterCollections.scss
+++ b/src/components/SearchFilterCollections.scss
@@ -2,11 +2,8 @@
 
 // Overrides some .pt-dialog CSS
 .search-filter-collections.pt-dialog {
-  left: ($pt-grid-size * 2);
-  right: ($pt-grid-size * 2);
   bottom: $pt-grid-size;
-  width: auto;
-  transform: scale(1);
+  width: calc(100% - #{$pt-grid-size * 4});
   padding: $pt-grid-size 0;
   flex-direction: row;
   background-color: $white;
@@ -72,8 +69,6 @@
 .search-filter-collections-facet {
   list-style: none;
   margin: 0;
-  padding: 0;
-
   padding: ($pt-grid-size / 2) 0;
 
   & > li {

--- a/src/components/SearchFilterCollections.scss
+++ b/src/components/SearchFilterCollections.scss
@@ -44,6 +44,7 @@
 
   & > li {
     position: relative;
+    cursor: pointer;
     padding: $pt-grid-size $pt-grid-size 0 ($pt-grid-size * 2 + 16px);
     overflow: auto;
     width: 100%;
@@ -60,6 +61,36 @@
 
     &:nth-child(odd) {
       background: $light-gray4;
+    }
+
+    &:hover {
+      background-color: $gray5;
+    }
+  }
+}
+
+.search-filter-collections-facet {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  padding: ($pt-grid-size / 2) 0;
+
+  & > li {
+    position: relative;
+    cursor: pointer;
+    padding: ($pt-grid-size / 2) $pt-grid-size;
+    padding-left: ($pt-icon-size-standard + $pt-grid-size * 2);
+
+    & > .pt-icon-standard {
+      position: absolute;
+      left: $pt-grid-size;
+      top: ($pt-grid-size / 2);
+      line-height: $pt-line-height;
+    }
+
+    &:hover {
+      background-color: $gray5;
     }
   }
 }

--- a/src/components/SearchFilterCollections.scss
+++ b/src/components/SearchFilterCollections.scss
@@ -2,14 +2,17 @@
 
 // Overrides some .pt-dialog CSS
 .search-filter-collections-dialog.pt-dialog {
-  top: $pt-grid-size;
-  bottom: $pt-grid-size;
+  top: ($pt-grid-size * 2);
+  bottom: ($pt-grid-size * 2);
   width: calc(100% - #{$pt-grid-size * 4});
+  margin-bottom: 0;
+  padding-bottom: $pt-grid-size;
 }
 
 .search-filter-collections {
   display: flex;
   height: 100%;
+  margin-top: $pt-grid-size;
 }
 
 .search-filter-collections-col {
@@ -23,7 +26,7 @@
 
   &:last-child {
     border-left: 2px solid $light-gray2;
-    width: 300px;
+    width: 250px;
   }
 }
 

--- a/src/components/SearchFilterCountries.js
+++ b/src/components/SearchFilterCountries.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Button, Popover, Position, Spinner } from '@blueprintjs/core';
+import orderBy from 'lodash/orderBy';
 
 import { endpoint } from '../api';
 
@@ -50,6 +51,8 @@ class SearchFilterCountries extends Component {
     const { currentValue } = this.props;
     const { countries, loaded } = this.state;
 
+    const isTicked = country => currentValue.indexOf(country.id) > -1;
+
     return (
       <Popover position={Position.BOTTOM} popoverWillOpen={this.onOpen} inline>
         <Button rightIconName="caret-down">
@@ -58,12 +61,11 @@ class SearchFilterCountries extends Component {
         </Button>
         {loaded ?
           <ul className="search-filter-countries">
-            {countries
-              .sort((a, b) => a.label < b.label ? -1 : 1)
+            {orderBy(countries, [isTicked, 'label'], ['desc', 'asc'])
               .map(country => (
                 <li onClick={this.toggleCountryId.bind(null, country.id)} key={country.id}>
                   <span className="pt-icon-standard pt-icon-tick"
-                    style={{'visibility': currentValue.indexOf(country.id) > -1 ? 'visible': 'hidden'}} />
+                    style={{'visibility': isTicked(country) ? 'visible': 'hidden'}} />
                   {country.label}
                 </li>
               ))}

--- a/src/components/SearchFilterCountries.js
+++ b/src/components/SearchFilterCountries.js
@@ -19,7 +19,7 @@ class SearchFilterCountries extends Component {
     };
 
     this.onOpen = this.onOpen.bind(this);
-    this.toggleCountryId = this.toggleCountryId.bind(this);
+    this.toggleCountry = this.toggleCountry.bind(this);
   }
 
   componentDidUpdate({ queryText }) {
@@ -40,7 +40,7 @@ class SearchFilterCountries extends Component {
     }
   }
 
-  toggleCountryId(countryId) {
+  toggleCountry(countryId) {
     const { currentValue, onChange } = this.props;
     const newValue = xor(currentValue, [countryId]);
     onChange(newValue);
@@ -63,7 +63,7 @@ class SearchFilterCountries extends Component {
             {countries
               .sort((a, b) => a.label < b.label ? -1 : 1)
               .map(country => (
-                <li onClick={this.toggleCountryId.bind(null, country.id)} key={country.id}>
+                <li onClick={this.toggleCountry.bind(null, country.id)} key={country.id}>
                   <SearchFilterTick isTicked={isTicked(country)} />
                   {country.label}
                 </li>

--- a/src/components/SearchFilterCountries.js
+++ b/src/components/SearchFilterCountries.js
@@ -1,39 +1,77 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Button, Popover, Position, Spinner } from '@blueprintjs/core';
 
+import { endpoint } from '../api';
+
 import './SearchFilterCountries.css';
 
-const SearchFilterCountries = ({ loaded, countries, currentValue, onOpen, onChange }) => {
+class SearchFilterCountries extends Component {
+  constructor(props) {
+    super(props);
 
-  function toggleCountryId(countryId) {
+    this.state = {
+      countries: [],
+      loaded: false
+    };
+
+    this.onOpen = this.onOpen.bind(this);
+    this.toggleCountryId = this.toggleCountryId.bind(this);
+  }
+
+  componentDidUpdate({ queryText }) {
+    if (queryText !== this.props.queryText) {
+      this.setState({loaded: false});
+    }
+  }
+
+  onOpen() {
+    if (!this.state.loaded) {
+      endpoint.get('search', {params: {q: this.props.queryText, facet: 'countries'}})
+        .then(response => {
+          this.setState({
+            countries: response.data.facets.countries.values,
+            loaded: true
+          });
+        });
+    }
+  }
+
+  toggleCountryId(countryId) {
+    const { currentValue, onChange } = this.props;
+
     const newValue = currentValue.indexOf(countryId) > -1 ?
       currentValue.filter(i => i !== countryId) : [...currentValue, countryId];
 
     onChange(newValue);
   }
 
-  return (
-    <Popover position={Position.BOTTOM} popoverWillOpen={onOpen} inline>
-      <Button rightIconName="caret-down">
-        <FormattedMessage id="search.countries" defaultMessage="Countries"/>
-        {loaded && <span> (<FormattedNumber value={countries.length} />)</span>}
-      </Button>
-      {loaded ?
-        <ul className="search-filter-countries">
-          {countries
-            .sort((a, b) => a.label < b.label ? -1 : 1)
-            .map(country => (
-              <li onClick={toggleCountryId.bind(null, country.id)} key={country.id}>
-                <span className="pt-icon-standard pt-icon-tick"
-                  style={{'visibility': currentValue.indexOf(country.id) > -1 ? 'visible': 'hidden'}} />
-                {country.label}
-              </li>
-            ))}
-        </ul> :
-        <Spinner className="search-filter-loading pt-large" />}
-    </Popover>
-  );
-};
+  render() {
+    const { currentValue } = this.props;
+    const { countries, loaded } = this.state;
+
+    return (
+      <Popover position={Position.BOTTOM} popoverWillOpen={this.onOpen} inline>
+        <Button rightIconName="caret-down">
+          <FormattedMessage id="search.countries" defaultMessage="Countries"/>
+          {loaded && <span> (<FormattedNumber value={countries.length} />)</span>}
+        </Button>
+        {loaded ?
+          <ul className="search-filter-countries">
+            {countries
+              .sort((a, b) => a.label < b.label ? -1 : 1)
+              .map(country => (
+                <li onClick={this.toggleCountryId.bind(null, country.id)} key={country.id}>
+                  <span className="pt-icon-standard pt-icon-tick"
+                    style={{'visibility': currentValue.indexOf(country.id) > -1 ? 'visible': 'hidden'}} />
+                  {country.label}
+                </li>
+              ))}
+          </ul> :
+          <Spinner className="search-filter-loading pt-large" />}
+      </Popover>
+    );
+  }
+}
 
 export default SearchFilterCountries;

--- a/src/components/SearchFilterCountries.js
+++ b/src/components/SearchFilterCountries.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Button, Popover, Position, Spinner } from '@blueprintjs/core';
-import orderBy from 'lodash/orderBy';
 import xor from 'lodash/xor';
 
 import { endpoint } from '../api';
+
+import SearchFilterTick from './SearchFilterTick';
 
 import './SearchFilterCountries.css';
 
@@ -59,11 +60,11 @@ class SearchFilterCountries extends Component {
         </Button>
         {loaded ?
           <ul className="search-filter-countries">
-            {orderBy(countries, [isTicked, 'label'], ['desc', 'asc'])
+            {countries
+              .sort((a, b) => a.label < b.label ? -1 : 1)
               .map(country => (
                 <li onClick={this.toggleCountryId.bind(null, country.id)} key={country.id}>
-                  <span className="pt-icon-standard pt-icon-tick"
-                    style={{'visibility': isTicked(country) ? 'visible': 'hidden'}} />
+                  <SearchFilterTick isTicked={isTicked(country)} />
                   {country.label}
                 </li>
               ))}

--- a/src/components/SearchFilterCountries.js
+++ b/src/components/SearchFilterCountries.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Button, Popover, Position, Spinner } from '@blueprintjs/core';
 import orderBy from 'lodash/orderBy';
+import xor from 'lodash/xor';
 
 import { endpoint } from '../api';
 
@@ -40,10 +41,7 @@ class SearchFilterCountries extends Component {
 
   toggleCountryId(countryId) {
     const { currentValue, onChange } = this.props;
-
-    const newValue = currentValue.indexOf(countryId) > -1 ?
-      currentValue.filter(i => i !== countryId) : [...currentValue, countryId];
-
+    const newValue = xor(currentValue, [countryId]);
     onChange(newValue);
   }
 

--- a/src/components/SearchFilterCountries.scss
+++ b/src/components/SearchFilterCountries.scss
@@ -17,7 +17,7 @@
     padding: ($pt-grid-size / 2) $pt-grid-size;
     padding-left: ($pt-icon-size-standard + $pt-grid-size * 2);
 
-    & > .pt-icon-standard {
+    & > .search-tick {
       position: absolute;
       left: $pt-grid-size;
       top: ($pt-grid-size / 2);

--- a/src/components/SearchFilterTick.js
+++ b/src/components/SearchFilterTick.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import c from 'classnames';
+
+const SearchFilterTick = ({ isTicked }) => (
+  <span className={c('pt-icon-standard', 'search-tick', {'is-ticked': isTicked})} />
+);
+
+export default SearchFilterTick;

--- a/src/components/SearchResultListItem.js
+++ b/src/components/SearchResultListItem.js
@@ -35,7 +35,7 @@ const SearchResultListItem = ({ result, collection }) => {
 };
 
 const mapStateToProps = ({ collections }, { result }) => ({
-  collection: collections[result.collection_id]
+  collection: collections.results[result.collection_id]
 });
 
 export default connect(mapStateToProps)(SearchResultListItem);

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -1,11 +1,19 @@
 import keyBy from 'lodash/keyBy';
 
-const initialState = {};
+const initialState = {
+  results: []
+};
 
 const collections = (state = initialState, action) => {
   switch (action.type) {
     case 'FETCH_COLLECTIONS_SUCCESS':
-      return { ...state, ...keyBy(action.collections.results, 'id') };
+      return {
+        ...action.collections,
+        results: {
+          ...state.results,
+          ...keyBy(action.collections.results, 'id')
+        }
+      };
     default:
       return state;
   }

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -43,7 +43,7 @@ class SearchScreen extends Component {
 
   fetchData() {
     const { query, fetchSearchResults } = this.props;
-    fetchSearchResults(query);
+    fetchSearchResults(pickBy(query, v => !!v));
   }
 
   updateQuery(newQuery) {

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -56,11 +56,11 @@ class SearchScreen extends Component {
   }
 
   render() {
+    const { query, searchResults } = this.props;
     return (
       <div>
-        <SearchFilter result={this.props.searchResults} query={this.props.query}
-          updateQuery={this.updateQuery} />
-        <SearchResultList result={this.props.searchResults} />
+        <SearchFilter result={searchResults} query={query} updateQuery={this.updateQuery} />
+        <SearchResultList result={searchResults} />
       </div>
     )
   }


### PR DESCRIPTION
Most new functionality is in the collections filter but there's been a major bit of refactoring of how the filters are loaded. Countries/collections now handle their own localised state and only expose the bits that list of selected countries/collections.

`SearchFilter` is now a much simpler component that could probably be made into a stateless functional component.

I've unified the UI a bit so that the countries tick list and collection facets are the same, this should probably be abstracted into a nice component at some point.

New functionality in collections component:
- Facets are fully functional
- Exposes selected collections to search (not visible in UI yet)
- Added a title to the dialog (woooo!)

There are other random changes too...